### PR TITLE
Use go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-4
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19.9-3
 
 USER root
 WORKDIR /tests

--- a/Dockerfile.load
+++ b/Dockerfile.load
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-4
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19.9-3
 
 USER root
 WORKDIR /tests


### PR DESCRIPTION
Use never version fo go for compilation.

Integration-service is dependency fo this tool and we plan to move to 1.19. It may cause issue on 1.18 in future as not all dependencies could be compiled with 1.18.